### PR TITLE
Remove deprecated set_output

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GitHub URL of the created tag
 ## Example usage
 
 ```yml
-uses: BarnabeD/gh-gem-tag-action@v1
+uses: duderman/gh-gem-tag-action@v1
 with:
   github_token: ${{ secrets.GITHUB_TOKEN }}
   tag_prefix: v

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ GitHub URL of the created tag
 ## Example usage
 
 ```yml
-uses: duderman/gh-gem-tag-action@v1
+uses: BarnabeD/gh-gem-tag-action@v1
 with:
   github_token: ${{ secrets.GITHUB_TOKEN }}
   tag_prefix: v

--- a/main.rb
+++ b/main.rb
@@ -162,7 +162,7 @@ Set it as a step parameter. F.e:
 end
 
 def set_ouput(name, value)
-  puts "#{name}=#{value}" >> $GITHUB_OUTPUT
+  puts $GITHUB_OUTPUT << "#{name}=#{value}"
 end
 
 gh_token = ARGV[0] || raise(ArgIsMissing, 'github_token')

--- a/main.rb
+++ b/main.rb
@@ -162,7 +162,7 @@ Set it as a step parameter. F.e:
 end
 
 def set_ouput(name, value)
-  puts "::set-output name=#{name}::#{value}"
+  puts "#{name}=#{value}" >> $GITHUB_OUTPUT
 end
 
 gh_token = ARGV[0] || raise(ArgIsMissing, 'github_token')


### PR DESCRIPTION
Github display warning for deprecated set_output in action's log.
Patch is super easy, so i did it ;)

source :
[github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)